### PR TITLE
feat: PRタイトル生成機能を追加 (pr.go)

### DIFF
--- a/pr.go
+++ b/pr.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -67,23 +69,21 @@ func createPR() {
 		os.Exit(1)
 	}
 
+	fmt.Println("\n🤖 Title")
 	template := loadTemplate(config.Template)
-	description, err := generatePRDescription(diff, template, config)
-	if err != nil {
-		errorPrint.Printf("Error generating PR description: %v\n", err)
-		os.Exit(1)
-	}
-
 	title, err := generatePRTitle(diff, config)
 	if err != nil {
 		errorPrint.Printf("Error generating PR title: %v\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Println("\n🤖 Title")
-	colorPrint.Println(title)
 	fmt.Println("\n🤖 Description")
-	colorPrint.Println(description)
+	description, err := generatePRDescription(diff, template, config)
+	if err != nil {
+		errorPrint.Printf("Error generating PR description: %v\n", err)
+		os.Exit(1)
+	}
+
 	fmt.Print("\n")
 
 	prompt := "\nDo you want to create a PR with this title and description? ([y]/n): "
@@ -197,7 +197,23 @@ func getPRDiff(baseBranch string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cmd := exec.Command("git", "diff", fmt.Sprintf("origin/%s...%s", baseBranch, currentBranch))
+
+	ignoreFiles := []string{
+		// TODO: Move this to a config file and allow users to customize
+		"package-lock.json",
+		"composer.lock",
+		"*.lock",
+		"go.sum",
+		"go.mod",
+	}
+	args := []string{"diff", fmt.Sprintf("origin/%s...%s", baseBranch, currentBranch), "--"}
+	for _, file := range ignoreFiles {
+		args = append(args, fmt.Sprintf(":!%s", file))
+	}
+
+	cmd := exec.Command(
+		"git", args...,
+	)
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -221,27 +237,25 @@ func getCurrentBranch() (string, error) {
 }
 
 func generatePRDescription(diff, template string, config Config) (string, error) {
-	fmt.Println("Generating PR description...")
-
+	colorPrint := color.New(color.FgHiGreen, color.Bold)
 	client := openai.NewClient(config.APIKey)
-	resp, err := client.CreateChatCompletion(
-    context.Background(),
-    openai.ChatCompletionRequest{
-        Model: openai.GPT4oMini,
-        Messages: []openai.ChatCompletionMessage{
-            {
-                Role:    openai.ChatMessageRoleSystem,
-                Content: `You are an AI assistant specialized in creating concise and informative Pull Request (PR) descriptions. Your task is to analyze the provided code diff and generate a clear, structured PR description that focuses on essential information. Follow these guidelines:
+
+	req := openai.ChatCompletionRequest{
+		Model: openai.GPT4oMini,
+		Messages: []openai.ChatCompletionMessage{
+			{
+					Role:    openai.ChatMessageRoleSystem,
+					Content: `You are an AI assistant specialized in creating concise and informative Pull Request (PR) descriptions. Your task is to analyze the provided code diff and generate a clear, structured PR description that focuses on essential information. Follow these guidelines:
 
 1. Title: Use the first line of the description as a clear, concise title that summarizes the main purpose of the changes.
 
 2. Overview: Provide a brief, high-level summary of the changes and their purpose. Limit this to 1-2 sentences.
 
 3. Detailed Changes: List all specific changes made, using bullet points. Group related changes and use sub-bullets for more detailed points. Focus on:
-   - Files modified
-   - Sections added, removed, or renamed
-   - New features or functionality added
-   - Specific improvements or clarifications made
+- Files modified
+- Sections added, removed, or renamed
+- New features or functionality added
+- Specific improvements or clarifications made
 
 4. Keep the description concise and to the point. Avoid unnecessary explanations or background information unless absolutely crucial for understanding the changes.
 
@@ -252,64 +266,102 @@ func generatePRDescription(diff, template string, config Config) (string, error)
 7. Ensure the description is free of grammatical errors and uses clear, professional language.
 
 The goal is to create a PR description that provides all necessary information about the changes in a brief, easily scannable format.`,
-            },
-            {
-                Role:    openai.ChatMessageRoleUser,
-                Content: fmt.Sprintf("Generate a Pull Request description in %s for the following diff, using this template:\n\nTemplate:\n%s\n\nDiff:\n%s", config.Language, template, diff),
-            },
-        },
-        MaxTokens: 800,
-    },
-	)
+			},
+			{
+					Role:    openai.ChatMessageRoleUser,
+					Content: fmt.Sprintf("Generate a Pull Request description in %s for the following diff, using this template:\n\nTemplate:\n%s\n\nDiff:\n%s", config.Language, template, diff),
+			},
+		},
+		MaxTokens: 800,
+		Stream: true,
+	}
+		
+	ctx := context.Background()
 
+	stream, err := client.CreateChatCompletionStream(ctx, req)
 	if err != nil {
 		return "", err
 	}
+	defer stream.Close()
 
-	return resp.Choices[0].Message.Content, nil
+	var fullResponse strings.Builder
+	
+	for {
+		response, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			fmt.Print("\n")
+			return fullResponse.String(), nil
+		}
+
+		if err != nil {
+			return "", err
+		}
+
+		content := response.Choices[0].Delta.Content
+		colorPrint.Print(content)
+		fullResponse.WriteString(content)
+	}
 }
 
 func generatePRTitle(diff string, config Config) (string, error) {
-	fmt.Println("Generating PR title...")
-
+	colorPrint := color.New(color.FgHiGreen, color.Bold)
 	client := openai.NewClient(config.APIKey)
-	resp, err := client.CreateChatCompletion(
-    context.Background(),
-    openai.ChatCompletionRequest{
-        Model: openai.GPT4oMini,
-        Messages: []openai.ChatCompletionMessage{
-            {
-                Role:    openai.ChatMessageRoleSystem,
-                Content: `You are an AI assistant that generates concise, informative, and impactful Pull Request titles based on the provided diff. Strictly adhere to these rules:
-                1. Start with an English type prefix (feat, fix, docs, style, refactor, test, chore) followed by a colon and a space.
-                2. Use the specified language for the main content of the title, unless English terms are more appropriate or widely used in the tech context.
-                3. Use present tense, imperative mood verbs (e.g., "Add", "Update", "Fix", "Implement" or their equivalents in the specified language).
-                4. Be extremely specific about the changes, focusing on the most important aspect.
-                5. Include the affected component, file, or module name.
-                6. Keep the title between 30-50 characters, prioritizing brevity and clarity.
-                7. If there's a ticket number, include it in square brackets at the beginning.
-                8. For breaking changes, start with "[BREAKING]".
-                9. Mention the programming language or framework only if it's the main focus of the change.
-                10. Use technical terms precisely and avoid general descriptions.
-                11. Exclude articles and unnecessary words to maximize information density.
-                12. For documentation changes, specify the exact nature of the update.
-                13. Blend languages appropriately if technical terms are better left in English.
-                Remember, the title should allow developers to immediately understand the core change without reading the full diff.`,
-            },
-            {
-                Role:    openai.ChatMessageRoleUser,
-                Content: fmt.Sprintf("Generate a short, impactful, and descriptive Pull Request title in %s for the following diff:\n\n%s", config.Language, diff),
-            },
-        },
-        MaxTokens: 60,
-    },
-	)
 
+	req := openai.ChatCompletionRequest{
+		Model: openai.GPT4oMini,
+		Messages: []openai.ChatCompletionMessage{
+			{
+					Role:    openai.ChatMessageRoleSystem,
+					Content: `You are an AI assistant that generates concise, informative, and impactful Pull Request titles based on the provided diff. Strictly adhere to these rules:
+					1. Start with an English type prefix (feat, fix, docs, style, refactor, test, chore) followed by a colon and a space.
+					2. Use the specified language for the main content of the title, unless English terms are more appropriate or widely used in the tech context.
+					3. Use present tense, imperative mood verbs (e.g., "Add", "Update", "Fix", "Implement" or their equivalents in the specified language).
+					4. Be extremely specific about the changes, focusing on the most important aspect.
+					5. Include the affected component, file, or module name.
+					6. Keep the title between 30-50 characters, prioritizing brevity and clarity.
+					7. If there's a ticket number, include it in square brackets at the beginning.
+					8. For breaking changes, start with "[BREAKING]".
+					9. Mention the programming language or framework only if it's the main focus of the change.
+					10. Use technical terms precisely and avoid general descriptions.
+					11. Exclude articles and unnecessary words to maximize information density.
+					12. For documentation changes, specify the exact nature of the update.
+					13. Blend languages appropriately if technical terms are better left in English.
+					Remember, the title should allow developers to immediately understand the core change without reading the full diff.`,
+			},
+			{
+					Role:    openai.ChatMessageRoleUser,
+					Content: fmt.Sprintf("Generate a short, impactful, and descriptive Pull Request title in %s for the following diff:\n\n%s", config.Language, diff),
+			},
+		},
+		MaxTokens: 60,
+		Stream: true,
+	}
+		
+	ctx := context.Background()
+
+	stream, err := client.CreateChatCompletionStream(ctx, req)
 	if err != nil {
 		return "", err
 	}
+	defer stream.Close()
+	
+	var fullResponse strings.Builder
+	
+	for {
+		response, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			fmt.Print("\n")
+			return fullResponse.String(), nil
+		}
 
-	return resp.Choices[0].Message.Content, nil
+		if err != nil {
+			return "", err
+		}
+
+		content := response.Choices[0].Delta.Content
+		colorPrint.Print(content)
+		fullResponse.WriteString(content)
+	}
 }
 
 func executePRCreate(title, body, baseBranch string) error {


### PR DESCRIPTION
## 概要
PRのタイトルと説明を生成する機能を拡張し、特定のファイルを無視する差分取得機能を追加しました。

## 変更内容
- **ファイルの変更**
  - `pr.go` を修正
  
- **主な変更点**
  - PRタイトルと説明の生成ロジックを変更
    - タイトル生成と説明生成の関数内でのエラーメッセージを改善
    - タイトル生成時にストリーミング応答を取得するように変更
    - 説明生成時にもストリーミング応答を取得するように変更
  - PR作成時に表示されるメッセージを整理
  - `getPRDiff`関数を更新し、無視すべきファイルを追加
    - 具体的には、`package-lock.json`, `composer.lock`, `*.lock`, `go.sum`, `go.mod` などを無視するよう設定
  
## その他
特定のファイルの無視リストは今後、設定ファイルに移動する予定です。