### PR TITLE
feat: gh-extension-precompileをv2に更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cli/gh-extension-precompile@v1
+      - uses: cli/gh-extension-precompile@v2
         with:
           generate_attestations: true
           go_version_file: go.mod
+        env:
+          CGO_ENABLED: 1


### PR DESCRIPTION
## 概要

リリースワークフローの一部であるGitHub Actionsの設定を更新しました。

## 目的

この変更により、`gh-extension-precompile`のバージョンをアップグレードし、環境変数を設定することでビルドプロセスを改善します。

## 実装の詳細

- `.github/workflows/release.yml`を変更
  - `cli/gh-extension-precompile`をバージョン1からバージョン2にアップグレード
  - `CGO_ENABLED`環境変数を設定し、goモジュールのビルド環境を強化

## 追加のコンテキスト

特に他の文脈はありません。

## レビューアへのメモ

アップグレードされたアクションによるビルド影響を重点的に確認してください。